### PR TITLE
Fix cli query syntax to use correct quote type

### DIFF
--- a/doc_source/ssl-config-update.md
+++ b/doc_source/ssl-config-update.md
@@ -47,7 +47,15 @@ You can use the default predefined security policy, `ELBSecurityPolicy-2016-08`,
 
 **To use a predefined SSL security policy**
 
-1. Use the following [describe\-load\-balancer\-policies](https://docs.aws.amazon.com/cli/latest/reference/elb/describe-load-balancer-policies.html) command to list the predefined security policies provided by Elastic Load Balancing:
+1. Use the following [describe\-load\-balancer\-policies](https://docs.aws.amazon.com/cli/latest/reference/elb/describe-load-balancer-policies.html) command to list the predefined security policies provided by Elastic Load Balancing\. The syntax that you use depends on the operating system and shell that you are using\.
+
+   **Linux**
+
+   ```
+   aws elb describe-load-balancer-policies --query 'PolicyDescriptions[?PolicyTypeName=='SSLNegotiationPolicyType'].{PolicyName:PolicyName}' --output table
+   ```
+
+   **Windows**
 
    ```
    aws elb describe-load-balancer-policies --query "PolicyDescriptions[?PolicyTypeName=='SSLNegotiationPolicyType'].{PolicyName:PolicyName}" --output table

--- a/doc_source/ssl-config-update.md
+++ b/doc_source/ssl-config-update.md
@@ -50,7 +50,7 @@ You can use the default predefined security policy, `ELBSecurityPolicy-2016-08`,
 1. Use the following [describe\-load\-balancer\-policies](https://docs.aws.amazon.com/cli/latest/reference/elb/describe-load-balancer-policies.html) command to list the predefined security policies provided by Elastic Load Balancing:
 
    ```
-   aws elb describe-load-balancer-policies --query "PolicyDescriptions[?PolicyTypeName==`SSLNegotiationPolicyType`].{PolicyName:PolicyName}" --output table
+   aws elb describe-load-balancer-policies --query "PolicyDescriptions[?PolicyTypeName=='SSLNegotiationPolicyType'].{PolicyName:PolicyName}" --output table
    ```
 
    The following is example output:


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
Updated quote type used in an example CLI query given here from backticks to single quotes.

Backticks result in the following error:
```
Bad value for --query PolicyDescriptions[?PolicyTypeName==].{PolicyName:PolicyName}: invalid token: Parse error at column 36, token "]" (RBRACKET), for expression:
"PolicyDescriptions[?PolicyTypeName==].{PolicyName:PolicyName}"
                                     ^
exit status 255
```

Whereas single quotes result in output like that given for example output in the document.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
