### PR TITLE
Fix wrong type for AdditionalAttributes in attribute.json example

### DIFF
--- a/doc_source/config-desync-mitigation-mode.md
+++ b/doc_source/config-desync-mitigation-mode.md
@@ -87,9 +87,11 @@ The following is the contents of `attribute.json`\.
 
 ```
 {
-    "AdditionalAttributes": {
-        "Key": "elb.http.desyncmitigationmode",
-        "Value": "strictest"
-    }
+    "AdditionalAttributes": [
+        {
+            "Key": "elb.http.desyncmitigationmode",
+            "Value": "strictest"
+        }
+    ]
 }
 ```


### PR DESCRIPTION
*Description of changes:* Fix wrong type for AdditionalAttributes in attribute.json example
Should be of type list, instead of dict.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
